### PR TITLE
Improve error message when IHDR is not first chunk

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -71,7 +71,7 @@ Parser.prototype._parseChunkBegin = function (data) {
   //    safeToCopy = Boolean(data[7] & 0x20); // or unsafe
 
   if (!this._hasIHDR && type !== constants.TYPE_IHDR) {
-    this.error(new Error("Expected IHDR on beggining"));
+    this.error(new Error("Expected IHDR to be first chunk"));
     return;
   }
 


### PR DESCRIPTION
This fixes a typo in the error message and (hopefully) makes it a little clearer.